### PR TITLE
chg: test: Changed logic in test_wrapper.sh 

### DIFF
--- a/test_wrapper.sh
+++ b/test_wrapper.sh
@@ -2,11 +2,19 @@
 
 cd /source
 
-BASE="py.test --cov=cloudpassage tests/style tests/unit"
-INTEGRATION="tests/integration"
+BASE="py.test --cov=cloudpassage /source/tests/style /source/tests/unit"
+INTEGRATION="py.test --cov=cloudpassage tests"
 CODECLIMATE="codeclimate-test-reporter --file=/source/.coverage --debug"
 SOURCE_CONFIG_TEMPLATE="/source/tests/configs/portal.yaml"
 LOCAL_CONFIG_FILE="/source/tests/configs/portal.yaml.local"
+
+# CodeClimate only records coverage for the default branch.  So if you have
+# convigured the CODECLIMATE_REPO_TOKEN variable, we switch to the `master`
+# branch before running tests and submitting results.
+
+if [ ${CODECLIMATE_REPO_TOKEN} ]; then
+  git checkout master
+fi
 
 if [ -z ${HALO_API_HOSTNAME} ]; then
   export HALO_API_HOSTNAME=api.cloudpassage.com
@@ -32,12 +40,13 @@ fi
 # set, so we then run integration tests.
 
 echo "Running style, unit, and integration tests"
-${BASE} ${INTEGRATION}
+${INTEGRATION}
 RETCODE=$?
 if [ ${RETCODE} != 0 ]; then
   exit ${RETCODE}
 fi
 
+# Finally, we use codeclimate-test-reporter to send in metrics.
 if [ ${CODECLIMATE_REPO_TOKEN} ]; then
   ${CODECLIMATE}
 fi


### PR DESCRIPTION
so that if the ${CODECLIMATE_REPO_TOKEN} var is set, it will switch to the master branch to run tests so that coverage will be accurately reported. !minor