### PR TITLE
scan history should use since and until

### DIFF
--- a/cloudpassage/scan.py
+++ b/cloudpassage/scan.py
@@ -136,7 +136,7 @@ class Scan(object):
         """
 
         max_pages = 20
-        url_params = {}
+        url_params = kwargs
         if "server_id" in kwargs:
             url_params["server_id"] = kwargs["server_id"]
         if "module" in kwargs:


### PR DESCRIPTION
specifically I was looking for `since` and `until`, but this should also fix any other param that the api will accept