### PR TITLE
fixes firewall log paging

### DIFF
--- a/cloudpassage/server.py
+++ b/cloudpassage/server.py
@@ -172,8 +172,7 @@ class Server(object):
 
         request = HttpHelper(self.session)
         response = request.get_paginated(endpoint, key, max_pages)
-        firewall_log_details = response[key]
-        return firewall_log_details
+        return response
 
     def command_details(self, server_id, command_id):
         """This method retrieves the details and status of a server command.


### PR DESCRIPTION
the `request.get_paginated(endpoint, key, max_pages)` already grabs the `key` on the response, so no need to do it again.

This is what you get without this change:

```
Traceback (most recent call last):
  File "firewall.py", line 30, in <module>
    for fw in server.get_firewall_logs(s['id'], 100):
  File "/home/sherzberg/workspace/cloudpassage-halo-python-sdk/cloudpassage/server.py", line 175, in get_firewall_logs
    firewall_log_details = response[key]
TypeError: list indices must be integers, not str
```