### PR TITLE
Add missing CHANGELOG.rst to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.rst


### PR DESCRIPTION
This should fix install errors I experienced on Python 3:

```
$ pip install cloudpassage
Collecting cloudpassage
  Downloading cloudpassage-1.0.7.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/nn/z9g63vc13hs4nbwv9bw7qwrrpqx5wr/T/pip-build-yo6p0b4o/cloudpassage/setup.py", line 35, in <module>
        long_description=get_long_description(["README.rst", "CHANGELOG.rst"]),
      File "/private/var/folders/nn/z9g63vc13hs4nbwv9bw7qwrrpqx5wr/T/pip-build-yo6p0b4o/cloudpassage/setup.py", line 20, in get_long_description
        retval = retval + (read(fname)) + "\n\n"
      File "/private/var/folders/nn/z9g63vc13hs4nbwv9bw7qwrrpqx5wr/T/pip-build-yo6p0b4o/cloudpassage/setup.py", line 7, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
    FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/nn/z9g63vc13hs4nbwv9bw7qwrrpqx5wr/T/pip-build-yo6p0b4o/cloudpassage/CHANGELOG.rst'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/nn/z9g63vc13hs4nbwv9bw7qwrrpqx5wr/T/pip-build-yo6p0b4o/cloudpassage/
```