### PR TITLE
Feature/time series

### DIFF
--- a/cloudpassage/__init__.py
+++ b/cloudpassage/__init__.py
@@ -31,7 +31,7 @@ from cloudpassage.scan import CveException  # noqa: F401
 from cloudpassage.scan import Scan  # noqa: F401
 from cloudpassage.server import Server  # noqa: F401
 from cloudpassage.server_group import ServerGroup  # noqa: F401
-from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa: F401
+from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa F401 E501
 from cloudpassage.system_announcement import SystemAnnouncement  # noqa: F401
 from cloudpassage.time_series import TimeSeries  # noqa: F401
 import utility as init_util

--- a/cloudpassage/__init__.py
+++ b/cloudpassage/__init__.py
@@ -31,7 +31,7 @@ from cloudpassage.scan import CveException  # noqa: F401
 from cloudpassage.scan import Scan  # noqa: F401
 from cloudpassage.server import Server  # noqa: F401
 from cloudpassage.server_group import ServerGroup  # noqa: F401
-from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa F401 E501
+from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa: F401, E501
 from cloudpassage.system_announcement import SystemAnnouncement  # noqa: F401
 from cloudpassage.time_series import TimeSeries  # noqa: F401
 import utility as init_util

--- a/cloudpassage/__init__.py
+++ b/cloudpassage/__init__.py
@@ -31,7 +31,7 @@ from cloudpassage.scan import CveException  # noqa: F401
 from cloudpassage.scan import Scan  # noqa: F401
 from cloudpassage.server import Server  # noqa: F401
 from cloudpassage.server_group import ServerGroup  # noqa: F401
-from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa: F401, E501
+from cloudpassage.special_events_policy import SpecialEventsPolicy  # NOQA
 from cloudpassage.system_announcement import SystemAnnouncement  # noqa: F401
 from cloudpassage.time_series import TimeSeries  # noqa: F401
 import utility as init_util

--- a/cloudpassage/__init__.py
+++ b/cloudpassage/__init__.py
@@ -26,13 +26,14 @@ from cloudpassage.issue import Issue  # noqa: F401
 from cloudpassage.lids_policy import LidsPolicy  # noqa: F401
 from cloudpassage.local_user_account import LocalUserAccount  # noqa: F401
 from cloudpassage.local_user_group import LocalUserGroup  # noqa: F401
+from cloudpassage.retry import Retry  # noqa: F401
 from cloudpassage.scan import CveException  # noqa: F401
 from cloudpassage.scan import Scan  # noqa: F401
 from cloudpassage.server import Server  # noqa: F401
 from cloudpassage.server_group import ServerGroup  # noqa: F401
 from cloudpassage.special_events_policy import SpecialEventsPolicy  # noqa: F401
 from cloudpassage.system_announcement import SystemAnnouncement  # noqa: F401
-from cloudpassage.retry import Retry  # noqa: F401
+from cloudpassage.time_series import TimeSeries  # noqa: F401
 import utility as init_util
 
 

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -3,9 +3,13 @@ import time
 import urllib
 from http_helper import HttpHelper
 from multiprocessing.dummy import Pool as ThreadPool
+from cloudpassage.exceptions import CloudPassageValidation
 
 
 class TimeSeries(object):
+
+    allowed_urls = ["/v1/events", "/v1/scans", "/v1/issues"]
+
     """Wrap time-series object retrieval in a generator.
 
     Args:
@@ -28,6 +32,7 @@ class TimeSeries(object):
         self.last_item_id = None
         self.params["since"] = start_time
         self.params["per_page"] = self.page_size
+        self.verify_start_url(start_url)
         return
 
     def __iter__(self):
@@ -219,3 +224,9 @@ class TimeSeries(object):
             items.extend(page[item_key])
         result = sorted(items, key=operator.itemgetter(sort_key))
         return result
+
+    @classmethod
+    def verify_start_url(cls, start_url):
+        if start_url not in cls.allowed_urls:
+            raise CloudPassageValidation
+        return

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -8,7 +8,7 @@ from cloudpassage.exceptions import CloudPassageValidation
 
 class TimeSeries(object):
 
-    allowed_urls = ["/v1/events", "/v1/scans", "/v1/issues"]
+    allowed_urls = ["/v1/events", "/v1/scans"]
 
     """Wrap time-series object retrieval in a generator.
 

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -8,7 +8,7 @@ from cloudpassage.exceptions import CloudPassageValidation
 
 class TimeSeries(object):
 
-    allowed_urls = ["/v1/events", "/v1/scans"]
+    allowed_urls = ["/v1/events", "/v1/scans", "/v1/issues"]
 
     """Wrap time-series object retrieval in a generator.
 

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -1,0 +1,221 @@
+import operator
+import time
+import urllib
+from http_helper import HttpHelper
+from multiprocessing.dummy import Pool as ThreadPool
+
+
+class TimeSeries(object):
+    """Wrap time-series object retrieval in a generator.
+
+    Args:
+        session(object): HaloSession object.
+        start_time(str): ISO 8601-formatted timestamp.
+        start_url(str): Path from URL, no hostname and no URL-encoded params.
+        item_key(str): Top-level key, below which is a list of target items.
+        params(dict): Parameters for URL, which will be URL-encoded.
+    """
+    def __init__(self, session, start_time, start_url, item_key, params={}):
+        self.url = start_url
+        self.params = params
+        self.start_url = start_url
+        self.batch_size = 10
+        self.page_size = 50
+        self.session = session
+        self.max_threads = self.session.threads
+        self.item_key = item_key
+        self.sort_key = "created_at"
+        self.last_item_id = None
+        self.params["since"] = start_time
+        self.params["per_page"] = self.page_size
+        return
+
+    def __iter__(self):
+        """Yields one item from a time-series query against Halo. Forever."""
+        while True:
+            for item in self.get_next_batch():
+                yield item
+
+    def adjust_batch_size(self, adjustment_factor):
+        """Adjust the batch size for subsequent queries against Halo API.
+
+        We will never take the batch size below 1 or over the original maximum
+        thread count.
+
+        Args:
+            adjustent_factor(int): Number, positive or negative, by which we
+                should increase or decrease the number of concurrent requsts
+                agains the Halo API.
+        """
+        target_batch_size = adjustment_factor + self.batch_size
+        if target_batch_size < 1:  # Don't go below one page.
+            self.batch_size = 1
+        elif target_batch_size > self.max_threads:  # Don't exceed max_threads.
+            self.batch_size = self.max_threads
+        else:
+            self.batch_size = target_batch_size
+        return
+
+    @classmethod
+    def create_url_batch(cls, path, batch_size, params={}):
+        """Create a batch of URLs for pulling time-series objects from Halo.
+
+        Args:
+            base_url(str): This is the path of the URL, not including hostname
+                or parameters.
+            batch_size(int): This is the number of URLs that will be generated.
+            params(dict): These are parameters that will be added to each URL.
+
+        Returns:
+            list: This returns a list of tuples, where the first item in the
+                tuple is the URL path, the second is the params to be appended
+                to the URL when retrieved.
+        """
+        url_list = []
+        for page in range(1, batch_size + 1):
+            params["page"] = page
+            url = (path, dict(params))
+            url_list.append(url)
+        return url_list
+
+    @classmethod
+    def get_adjustment_factor(cls, pages, page_size, item_key):
+        """Return adjustment factor, to optimize parallelization of API req.
+
+        Args:
+            pages(list): Pages from query.
+            page_size(int): Number of items in a full page
+
+        Returns:
+            int: Positive or negative integer, which should be used to either
+                increase or decrease the number of threads used to pull pages
+                from the Halo API.
+        """
+        total_pages = len(pages)
+        full_pages = cls.get_number_of_full_pages(pages, page_size, item_key)
+        empty_pages = cls.get_number_of_empty_pages(pages, item_key)
+        if empty_pages == 0:
+            if total_pages == full_pages:
+                adjustment_factor = 1
+            else:
+                adjustment_factor = 0
+        elif full_pages == 0:
+            adjustment_factor = -9
+        else:
+            adjustment_factor = -1
+        return adjustment_factor
+
+    def get_next_batch(self):
+        """Gets the next batch of time-series items from the Halo API"""
+        url_list = self.create_url_batch(self.start_url, self.batch_size,
+                                         self.params)
+        pages = self.get_pages(url_list)
+        adjustment_factor = self.get_adjustment_factor(pages, self.page_size,
+                                                       self.item_key)
+        self.adjust_batch_size(adjustment_factor)
+        items = self.sorted_items_from_pages(pages, self.item_key,
+                                             self.sort_key)
+        items = self.remove_duplicate_items(items)
+        try:
+            if items[0]["id"] == self.last_item_id:
+                del items[0]
+        except IndexError:  # This happens when the return set is empty...
+            time.sleep(3)
+            return []
+        try:
+            last_item_timestamp = items[-1]['created_at']
+            last_item_id = items[-1]['id']
+        except IndexError:
+            time.sleep(3)
+            return []
+        self.params["since"] = last_item_timestamp
+        self.last_item_id = last_item_id
+        return items
+
+    @classmethod
+    def get_number_of_empty_pages(cls, pages, item_key):
+        """Determine number of empty pages from list of pages.
+
+        Args:
+            pages(list): List of pages as pulled from Halo API.
+            item_key(str): Top-level key, below which are target items.
+
+        Returns:
+            int: Number of ampty pages from query.
+        """
+        empty = [page for page in pages if page[item_key] == []]
+        return len(empty)
+
+    @classmethod
+    def get_number_of_full_pages(cls, pages, page_size, item_key):
+        """Return the number of full pages from query.
+
+        Args:
+            pages(list): List of pages as pulled from Halo API.
+            page_size(int): Expected number of items found in a full page.
+            item_key(str): Top-level key, below which are target items.
+
+        Returns:
+            int: Number of full pages in query.
+        """
+        full = [page for page in pages if len(page[item_key]) == page_size]
+        return len(full)
+
+    def get_pages(self, url_list):
+        """Map URLs to threads, return all when complete"""
+        page_helper = self.get_page
+        pool = ThreadPool(self.max_threads)
+        results = pool.map(page_helper, url_list)
+        pool.close()
+        pool.join()
+        return results
+
+    def get_page(self, get_tup):
+        """Gets one page's contents.
+
+        Args:
+            get_tup(tuple): First item in tuple is a string, the URL.  The
+                second item is the params to be used in the query.
+
+        Returns:
+            dict: Page contents as dict
+        """
+        helper = HttpHelper(self.session)
+        path, args = get_tup[0], get_tup[1]
+        url = "{path}?{opts}".format(path=path,
+                                     opts=urllib.urlencode(dict(args)))
+        results = helper.get(url)
+        return results
+
+    @classmethod
+    def remove_duplicate_items(cls, items_in):
+        """Remove duplicate items by id."""
+        items_out = []
+        item_ids = set([])
+        for item in items_in:
+            if item["id"] not in item_ids:
+                item_ids.add(item["id"])
+                items_out.append(item)
+            else:
+                continue
+        return items_out
+
+    @classmethod
+    def sorted_items_from_pages(cls, pages, item_key, sort_key):
+        """Return all items, sorted by specific key.
+
+        Args:
+            pages(list): Pages from (multiple) API queries.  Raw JSON.
+            item_key(str): Top-level key, below which are target items.
+            sort_key(str): Key which is present in every item, by which the
+                entire result will be sorted.
+
+        Returns:
+            list: List of items, extracted from pages using item_key, and
+                sorted by sort_key.
+        """
+        items = []
+        for page in pages:
+            items.extend(page[item_key])
+        result = sorted(items, key=operator.itemgetter(sort_key))
+        return result

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -19,10 +19,10 @@ class TimeSeries(object):
         self.url = start_url
         self.params = params
         self.start_url = start_url
-        self.batch_size = 10
+        self.batch_size = 1
         self.page_size = 50
         self.session = session
-        self.max_threads = self.session.threads
+        self.max_threads = 10
         self.item_key = item_key
         self.sort_key = "created_at"
         self.last_item_id = None

--- a/cloudpassage/time_series.py
+++ b/cloudpassage/time_series.py
@@ -228,5 +228,6 @@ class TimeSeries(object):
     @classmethod
     def verify_start_url(cls, start_url):
         if start_url not in cls.allowed_urls:
-            raise CloudPassageValidation
+            exc_msg = "This URL is unsupported for TimeSeries: %s" % start_url
+            raise CloudPassageValidation(exc_msg)
         return

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Contents:
    fim_baseline
    lids_policy
    scan
+   issue
    event
    system_announcement
    special_events_policy

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    api_key_manager
    halo_session
    http_helper
+   time_series
    server
    server_group
    configuration_policy

--- a/docs/source/issue.rst
+++ b/docs/source/issue.rst
@@ -1,0 +1,7 @@
+Issue
+=====
+
+.. toctree::
+
+.. autoclass:: cloudpassage.Issue
+   :members: list_all

--- a/docs/source/time_series.rst
+++ b/docs/source/time_series.rst
@@ -1,0 +1,7 @@
+TimeSeries
+==========
+
+.. toctree::
+
+.. autoclass:: cloudpassage.TimeSeries
+   :members:

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -35,19 +35,19 @@ class TestIntegrationTimeSeries(object):
         """Test against events endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
-                                                            timedelta(7)))
+                                                            timedelta(30)))
         start_url = "/v1/eventss"
         item_key = "events"
         with pytest.raises(cloudpassage.ValidationError):
             streamer = cloudpassage.TimeSeries(session, start_time,
                                                start_url, item_key)
-            assert False  # Break if exception is not caught.
+        assert True
 
     def test_time_series_iter_events_many_pages(self):
         """Test against events endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
-                                                            timedelta(7)))
+                                                            timedelta(30)))
         start_url = "/v1/events"
         item_key = "events"
         streamer = cloudpassage.TimeSeries(session, start_time,
@@ -66,7 +66,7 @@ class TestIntegrationTimeSeries(object):
         """Test against scans endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
-                                                            timedelta(7)))
+                                                            timedelta(30)))
         start_url = "/v1/scans"
         item_key = "scans"
         streamer = cloudpassage.TimeSeries(session, start_time,
@@ -85,7 +85,7 @@ class TestIntegrationTimeSeries(object):
         """Test against issues endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
-                                                            timedelta(7)))
+                                                            timedelta(30)))
         start_url = "/v1/issues"
         item_key = "issues"
         streamer = cloudpassage.TimeSeries(session, start_time,

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -2,6 +2,8 @@ import imp
 import os
 import sys
 
+from datetime import datetime, timedelta
+
 
 module_name = 'cloudpassage'
 here_dir = os.path.dirname(os.path.abspath(__file__))
@@ -30,7 +32,8 @@ class TestIntegrationTimeSeries(object):
 
     def test_time_series_iter_events_many_pages(self):
         session = self.get_halo_session()
-        start_time = "2017-10-01"
+        start_time = cloudpassage.Utility.datetime_to_8601((datetime.now() -
+                                                            timedelta(7)))
         start_url = "/v1/events"
         item_key = "events"
         event_streamer = cloudpassage.TimeSeries(session, start_time,

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -37,7 +37,6 @@ class TestIntegrationTimeSeries(object):
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
         test_scenarios = [{"start_url": "/v1/events", "item_key": "events"},
-                          {"start_url": "/v1/issues", "item_key": "issues"},
                           {"start_url": "/v1/scans", "item_key": "scans"}]
         for scenario in test_scenarios:
             start_url = scenario["start_url"]
@@ -55,7 +54,7 @@ class TestIntegrationTimeSeries(object):
                     break
 
     def test_time_series_iter_items_many_pages_fail(self):
-        """Test against events, issues, and scans endpoints."""
+        """Test failures for bad endpoints."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
@@ -68,4 +67,4 @@ class TestIntegrationTimeSeries(object):
             with pytest.raises(cloudpassage.ValidationError):
                 streamer = cloudpassage.TimeSeries(session, start_time,
                                                    start_url, item_key)
-                assert False
+                assert False  # Break if exception is not caught.

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -31,40 +31,71 @@ class TestIntegrationTimeSeries(object):
                                            integration_string="SDK-Smoke")
         return session
 
-    def test_time_series_iter_items_many_pages(self):
-        """Test against events, issues, and scans endpoints."""
+    def test_time_series_iter_events_many_pages_fail(self):
+        """Test against events endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
-        test_scenarios = [{"start_url": "/v1/events", "item_key": "events"},
-                          {"start_url": "/v1/scans", "item_key": "scans"}]
-        for scenario in test_scenarios:
-            start_url = scenario["start_url"]
-            item_key = scenario["item_key"]
+        start_url = "/v1/eventss"
+        item_key = "events"
+        with pytest.raises(cloudpassage.ValidationError):
             streamer = cloudpassage.TimeSeries(session, start_time,
                                                start_url, item_key)
-            item_counter = 0
-            item_ids = set([])
-            for item in streamer:
-                assert "id" in item
-                assert item["id"] not in item_ids
-                item_ids.add(item["id"])
-                item_counter += 1
-                if item_counter > 60:
-                    break
+            assert False  # Break if exception is not caught.
 
-    def test_time_series_iter_items_many_pages_fail(self):
-        """Test failures for bad endpoints."""
+    def test_time_series_iter_events_many_pages(self):
+        """Test against events endpoint."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
-        test_scenarios = [{"start_url": "/v1/eventss", "item_key": "events"},
-                          {"start_url": "/v1/issuess", "item_key": "issues"},
-                          {"start_url": "/v1/scanss", "item_key": "scans"}]
-        for scenario in test_scenarios:
-            start_url = scenario["start_url"]
-            item_key = scenario["item_key"]
-            with pytest.raises(cloudpassage.ValidationError):
-                streamer = cloudpassage.TimeSeries(session, start_time,
-                                                   start_url, item_key)
-                assert False  # Break if exception is not caught.
+        start_url = "/v1/events"
+        item_key = "events"
+        streamer = cloudpassage.TimeSeries(session, start_time,
+                                           start_url, item_key)
+        item_counter = 0
+        item_ids = set([])
+        for item in streamer:
+            assert "id" in item
+            assert item["id"] not in item_ids
+            item_ids.add(item["id"])
+            item_counter += 1
+            if item_counter > 60:
+                break
+
+    def test_time_series_iter_scans_many_pages(self):
+        """Test against scans endpoint."""
+        session = self.get_halo_session()
+        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
+                                                            timedelta(7)))
+        start_url = "/v1/scans"
+        item_key = "scans"
+        streamer = cloudpassage.TimeSeries(session, start_time,
+                                           start_url, item_key)
+        item_counter = 0
+        item_ids = set([])
+        for item in streamer:
+            assert "id" in item
+            assert item["id"] not in item_ids
+            item_ids.add(item["id"])
+            item_counter += 1
+            if item_counter > 60:
+                break
+
+    def test_time_series_iter_issues_many_pages(self):
+        """Test against issues endpoint."""
+        session = self.get_halo_session()
+        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
+                                                            timedelta(7)))
+        start_url = "/v1/issues"
+        item_key = "issues"
+        streamer = cloudpassage.TimeSeries(session, start_time,
+                                           start_url, item_key)
+        item_counter = 0
+        item_ids = set([])
+        for item in streamer:
+            assert "id" in item
+            assert item["id"] not in item_ids
+            item_ids.add(item["id"])
+            item_counter += 1
+            if item_counter > 60:
+                break

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -30,20 +30,25 @@ class TestIntegrationTimeSeries(object):
                                            integration_string="SDK-Smoke")
         return session
 
-    def test_time_series_iter_events_many_pages(self):
+    def test_time_series_iter_items_many_pages(self):
+        """Test against events, issues, and scans endpoints."""
         session = self.get_halo_session()
         start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
-        start_url = "/v1/events"
-        item_key = "events"
-        event_streamer = cloudpassage.TimeSeries(session, start_time,
-                                                 start_url, item_key)
-        event_counter = 0
-        event_ids = set([])
-        for event in event_streamer:
-            assert "id" in event
-            assert event["id"] not in event_ids
-            event_ids.add(event["id"])
-            event_counter += 1
-            if event_counter > 60:
-                break
+        test_scenarios = [{"start_url": "/v1/events", "item_key": "events"},
+                          {"start_url": "/v1/issues", "item_key": "issues"},
+                          {"start_url": "/v1/scans", "item_key": "scans"}]
+        for scenario in test_scenarios:
+            start_url = scenario["start_url"]
+            item_key = scenario["item_key"]
+            streamer = cloudpassage.TimeSeries(session, start_time,
+                                               start_url, item_key)
+            item_counter = 0
+            item_ids = set([])
+            for item in streamer:
+                assert "id" in item
+                assert item["id"] not in item_ids
+                item_ids.add(item["id"])
+                item_counter += 1
+                if item_counter > 60:
+                    break

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -39,8 +39,8 @@ class TestIntegrationTimeSeries(object):
         start_url = "/v1/eventss"
         item_key = "events"
         with pytest.raises(cloudpassage.CloudPassageValidation):
-            streamer = cloudpassage.TimeSeries(session, start_time,
-                                               start_url, item_key)
+            stream = cloudpassage.TimeSeries(session, start_time,  # noqa F841
+                                             start_url, item_key)
         assert True
 
     def test_time_series_iter_events_many_pages(self):

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -41,6 +41,7 @@ class TestIntegrationTimeSeries(object):
         with pytest.raises(cloudpassage.CloudPassageValidation):
             stream = cloudpassage.TimeSeries(session, start_time,  # noqa F841
                                              start_url, item_key)
+            assert False  # Should bail and never hit this assertion.
         assert True
 
     def test_time_series_iter_events_many_pages(self):

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -62,25 +62,6 @@ class TestIntegrationTimeSeries(object):
             if item_counter > 60:
                 break
 
-    def test_time_series_iter_scans_many_pages(self):
-        """Test against scans endpoint."""
-        session = self.get_halo_session()
-        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
-                                                            timedelta(30)))
-        start_url = "/v1/scans"
-        item_key = "scans"
-        streamer = cloudpassage.TimeSeries(session, start_time,
-                                           start_url, item_key)
-        item_counter = 0
-        item_ids = set([])
-        for item in streamer:
-            assert "id" in item
-            assert item["id"] not in item_ids
-            item_ids.add(item["id"])
-            item_counter += 1
-            if item_counter > 60:
-                break
-
     def test_time_series_iter_issues_many_pages(self):
         """Test against issues endpoint."""
         session = self.get_halo_session()
@@ -97,5 +78,24 @@ class TestIntegrationTimeSeries(object):
             assert item["id"] not in item_ids
             item_ids.add(item["id"])
             item_counter += 1
-            if item_counter > 60:
+            if item_counter > 5:
+                break
+
+    def test_time_series_iter_scans_many_pages(self):
+        """Test against scans endpoint."""
+        session = self.get_halo_session()
+        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
+                                                            timedelta(30)))
+        start_url = "/v1/scans"
+        item_key = "scans"
+        streamer = cloudpassage.TimeSeries(session, start_time,
+                                           start_url, item_key)
+        item_counter = 0
+        item_ids = set([])
+        for item in streamer:
+            assert "id" in item
+            assert item["id"] not in item_ids
+            item_ids.add(item["id"])
+            item_counter += 1
+            if item_counter > 5:
                 break

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -38,7 +38,7 @@ class TestIntegrationTimeSeries(object):
                                                             timedelta(30)))
         start_url = "/v1/eventss"
         item_key = "events"
-        with pytest.raises(cloudpassage.ValidationError):
+        with pytest.raises(cloudpassage.CloudPassageValidation):
             streamer = cloudpassage.TimeSeries(session, start_time,
                                                start_url, item_key)
         assert True

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -13,14 +13,19 @@ cloudpassage = imp.load_module(module_name, fp, pathname, description)
 
 class TestIntegrationTimeSeries(object):
     def get_halo_session(self):
-        halo_key = os.getenv("HALO_API_KEY")
-        halo_secret = os.getenv("HALO_API_SECRET")
-        if None not in [halo_key, halo_secret]:
-            session = cloudpassage.HaloSession(halo_key, halo_secret)
-        else:
-            print("No API authentication env vars set!")
-            print("You must set HALO_API_KEY, HALO_API_SECRET to test this!")
-            raise ValueError
+        config_file_name = "portal.yaml.local"
+        tests_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 "../"))
+        config_file = os.path.join(tests_dir, "configs/", config_file_name)
+        session_info = cloudpassage.ApiKeyManager(config_file=config_file)
+        key_id = session_info.key_id
+        secret_key = session_info.secret_key
+        api_hostname = session_info.api_hostname
+        api_port = session_info.api_port
+        session = cloudpassage.HaloSession(key_id, secret_key,
+                                           api_host=api_hostname,
+                                           api_port=api_port,
+                                           integration_string="SDK-Smoke")
         return session
 
     def test_time_series_iter_events_many_pages(self):

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -1,0 +1,41 @@
+import imp
+import os
+import sys
+
+
+module_name = 'cloudpassage'
+here_dir = os.path.dirname(os.path.abspath(__file__))
+module_path = os.path.join(here_dir, '../../')
+sys.path.append(module_path)
+fp, pathname, description = imp.find_module(module_name)
+cloudpassage = imp.load_module(module_name, fp, pathname, description)
+
+
+class TestIntegrationTimeSeries(object):
+    def get_halo_session(self):
+        halo_key = os.getenv("HALO_API_KEY")
+        halo_secret = os.getenv("HALO_API_SECRET")
+        if None not in [halo_key, halo_secret]:
+            session = cloudpassage.HaloSession(halo_key, halo_secret)
+        else:
+            print("No API authentication env vars set!")
+            print("You must set HALO_API_KEY, HALO_API_SECRET to test this!")
+            raise ValueError
+        return session
+
+    def test_time_series_iter_events_many_pages(self):
+        session = self.get_halo_session()
+        start_time = "2017-10-01"
+        start_url = "/v1/events"
+        item_key = "events"
+        event_streamer = cloudpassage.TimeSeries(session, start_time,
+                                                 start_url, item_key)
+        event_counter = 0
+        event_ids = set([])
+        for event in event_streamer:
+            assert "id" in event
+            assert event["id"] not in event_ids
+            event_ids.add(event["id"])
+            event_counter += 1
+            if event_counter > 60:
+                break

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -1,5 +1,6 @@
 import imp
 import os
+import pytest
 import sys
 
 from datetime import datetime, timedelta
@@ -52,3 +53,19 @@ class TestIntegrationTimeSeries(object):
                 item_counter += 1
                 if item_counter > 60:
                     break
+
+    def test_time_series_iter_items_many_pages_fail(self):
+        """Test against events, issues, and scans endpoints."""
+        session = self.get_halo_session()
+        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
+                                                            timedelta(7)))
+        test_scenarios = [{"start_url": "/v1/eventss", "item_key": "events"},
+                          {"start_url": "/v1/issuess", "item_key": "issues"},
+                          {"start_url": "/v1/scanss", "item_key": "scans"}]
+        for scenario in test_scenarios:
+            start_url = scenario["start_url"]
+            item_key = scenario["item_key"]
+            with pytest.raises(cloudpassage.ValidationError):
+                streamer = cloudpassage.TimeSeries(session, start_time,
+                                                   start_url, item_key)
+                assert False

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -32,7 +32,7 @@ class TestIntegrationTimeSeries(object):
 
     def test_time_series_iter_events_many_pages(self):
         session = self.get_halo_session()
-        start_time = cloudpassage.Utility.datetime_to_8601((datetime.now() -
+        start_time = cloudpassage.utility.datetime_to_8601((datetime.now() -
                                                             timedelta(7)))
         start_url = "/v1/events"
         item_key = "events"

--- a/tests/integration/test_integration_time_series.py
+++ b/tests/integration/test_integration_time_series.py
@@ -39,8 +39,8 @@ class TestIntegrationTimeSeries(object):
         start_url = "/v1/eventss"
         item_key = "events"
         with pytest.raises(cloudpassage.CloudPassageValidation):
-            stream = cloudpassage.TimeSeries(session, start_time,  # noqa F841
-                                             start_url, item_key)
+            cloudpassage.TimeSeries(session, start_time,
+                                    start_url, item_key)
             assert False  # Should bail and never hit this assertion.
         assert True
 

--- a/tests/unit/test_unit_time_series.py
+++ b/tests/unit/test_unit_time_series.py
@@ -1,0 +1,133 @@
+import imp
+import os
+import sys
+
+
+module_name = 'cloudpassage'
+here_dir = os.path.dirname(os.path.abspath(__file__))
+module_path = os.path.join(here_dir, '../../')
+sys.path.append(module_path)
+fp, pathname, description = imp.find_module(module_name)
+cloudpassage = imp.load_module(module_name, fp, pathname, description)
+
+
+class TestUnitTimeSeries(object):
+    def test_unit_time_series_build_url_list(self):
+        path = "/v1/whatever"
+        params = {"server": "heyhowdy"}
+        count = 0
+        for item in cloudpassage.TimeSeries.create_url_batch(path, 5, params):
+            count += 1
+            assert item[0] == path
+            assert item[1]["server"] == "heyhowdy"
+            assert item[1]["page"] == count
+        assert count == 5
+
+    def test_unit_time_series_sorted_items_from_pages(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": [
+                    {"item_number": 2,
+                     "nonsort": "somesuch"},
+                    {"item_number": 3,
+                     "nonsort": "somesuch"}]}
+        pages = [page1, page2]
+        s = cloudpassage.TimeSeries.sorted_items_from_pages(pages, "whatevers",
+                                                            "item_number")
+        count = 0
+        for item in s:
+            count += 1
+            assert item["item_number"] == count
+        assert count == 4
+
+    def test_unit_time_series_get_number_of_empty_pages(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": []}
+        pages = [page1, page2]
+        pkey = "whatevers"
+        expected = 1
+        actual = cloudpassage.TimeSeries.get_number_of_empty_pages(pages, pkey)
+        assert expected == actual
+
+    def test_unit_time_series_get_number_of_full_pages(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": []}
+        pages = [page1, page2]
+        pkey = "whatevers"
+        expected = 1
+        actual = cloudpassage.TimeSeries.get_number_of_full_pages(pages,
+                                                                  2, pkey)
+        assert expected == actual
+
+    def test_unit_time_series_get_adjustment_factor_zero(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": [
+                    {"item_number": 2,
+                     "nonsort": "somesuch"}]}
+        pages = [page1, page2]
+        pkey = "whatevers"
+        expected = 0
+        actual = cloudpassage.TimeSeries.get_adjustment_factor(pages, 2, pkey)
+        assert expected == actual
+
+    def test_unit_time_series_get_adjustment_factor_up_one(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": [
+                    {"item_number": 2,
+                     "nonsort": "somesuch"},
+                    {"item_number": 3,
+                     "nonsort": "somesuch"}]}
+        pages = [page1, page2]
+        pkey = "whatevers"
+        expected = 1
+        actual = cloudpassage.TimeSeries.get_adjustment_factor(pages, 2, pkey)
+        assert expected == actual
+
+    def test_unit_time_series_get_adjustment_factor_down_one(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"},
+                    {"item_number": 4,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": [
+                    {"item_number": 2,
+                     "nonsort": "somesuch"},
+                    {"item_number": 3,
+                     "nonsort": "somesuch"}]}
+        page3 = {"whatevers": []}
+        pages = [page1, page2, page3]
+        pkey = "whatevers"
+        expected = -1
+        actual = cloudpassage.TimeSeries.get_adjustment_factor(pages, 2, pkey)
+        assert expected == actual
+
+    def test_unit_time_series_get_adjustment_factor_big_drop(self):
+        page1 = {"whatevers": [
+                    {"item_number": 1,
+                     "nonsort": "somesuch"}]}
+        page2 = {"whatevers": []}
+        page3 = {"whatevers": []}
+        pages = [page1, page2, page3]
+        pkey = "whatevers"
+        expected = -9
+        actual = cloudpassage.TimeSeries.get_adjustment_factor(pages, 2, pkey)
+        assert expected == actual


### PR DESCRIPTION
Tests pass, docs included.

This creates the TimeSeries class that facilitates threading in a very conservative way.  The number of threads starts at one, and only increases the number of threads if all pages in a batch come back completely full.  Similarly, if pages in a batch come back empty, the number of threads will decrease.  The number of concurrent requests, at full throttle, will never exceed 10.