### PR TITLE
chg: usr: Updated requests version pin to >=2.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
 
 Requirements:
 
-* Python 2.7.10 or newer (CloudPassage Halo Python SDK is not compatiable with Python 3)
+* Python 2.7.10 or newer (CloudPassage Halo Python SDK is not compatible with Python 3)
 * OpenSSL 1.0.2 or newer
-* requests
+* requests 2.18 or newer
 * pyaml
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pyaml
-requests>=2.7

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     keywords="cloudpassage halo api sdk",
     url="http://github.com/cloudpassage/cloudpassage-halo-python-sdk",
     packages=["cloudpassage"],
-    install_requires=["requests", "pyaml"],
+    install_requires=["requests>=2.18", "pyaml"],
     long_description=get_long_description(["README.rst", "CHANGELOG.rst"]),
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Removed requirements.txt file, which was unnecessary. The
setup.py file is used by easy_install to ensure dependencies
are in place.
Closes #118